### PR TITLE
fix: delayed stakes getter

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Kleros Courts on xDai
 xDai:
 - Wrapped PNK: `0xcb3231aBA3b451343e0Fddfc45883c842f223846`
 - xKlerosLiquid: `0x9C1dA9A04925bDfDedf0f6421bC7EEa8305F9002`
-- xKlerosLiquidExtraViews: `0xFA71f907B48f27d22f670d9E446f8137b0769e4B`
+- xKlerosLiquidExtraViews: `0xA60f464d5b71B5D2960713c8D1F95243cd2CFa78`
 - PolicyRegistry: `0x9d494768936b6bDaabc46733b8D53A937A6c6D7e`
 - SortitionSumTreeFactory: `0x7AE716d9935F41F173D944FE6557c1e117d561E9`
 - ProxyAdmin: `0xD1a711a863aFB85D1b4E721DcB3e48C477E46475`
@@ -14,7 +14,7 @@ xDai:
 Sokol:
 - Wrapped PNK: `0x9Bc02E9f5291adbb1f0Cf5C15ab1B400dccd3665`
 - xKlerosLiquid: `0xb701ff19fBD9702DD7Ca099Ee7D0D42a2612baB5`
-- xKlerosLiquidExtraViews: `0x1Aab57DD59afc98bff1D939b34974E9c8fc705fF`
+- xKlerosLiquidExtraViews: `0x60AdebC3C75f4d1811cc842eee3E6287913B33A5`
 - PolicyRegistry: `0x0Bee63bC7220d0Bacd8A3c9d6B6511126CDfe58f`
 
 # Testing PNK on Sokol-Kovan

--- a/contracts/kleros/xKlerosLiquidExtraViews.sol
+++ b/contracts/kleros/xKlerosLiquidExtraViews.sol
@@ -1,6 +1,7 @@
 /**
  *  https://contributing.kleros.io/smart-contract-workflow
- *  @reviewers: [@hbarcelos]
+ *  @authors: [@fnanni-0]
+ *  @reviewers: [@hbarcelos*]
  *  @auditors: []
  *  @bounties: []
  *  @deployments: []

--- a/contracts/kleros/xKlerosLiquidExtraViews.sol
+++ b/contracts/kleros/xKlerosLiquidExtraViews.sol
@@ -11,7 +11,7 @@ import { xKlerosLiquid } from "./xKlerosLiquid.sol";
 
 /**
  *  @title xKlerosLiquidExtraViews
- *  @dev This contract is an adaption of Mainnet's xKlerosLiquidExtraViews (https://github.com/kleros/kleros/blob/69cfbfb2128c29f1625b3a99a3183540772fda08/contracts/kleros/KlerosLiquidExtraViews.sol)
+ *  @dev This contract is an adaption of Mainnet's KlerosLiquidExtraViews (https://github.com/kleros/kleros/blob/69cfbfb2128c29f1625b3a99a3183540772fda08/contracts/kleros/KlerosLiquidExtraViews.sol)
  *  for xDai chain.
  */
 contract xKlerosLiquidExtraViews {

--- a/contracts/kleros/xKlerosLiquidExtraViews.sol
+++ b/contracts/kleros/xKlerosLiquidExtraViews.sol
@@ -75,6 +75,8 @@ contract xKlerosLiquidExtraViews {
             (address account, uint96 subcourtID, uint128 stake) = klerosLiquid.delayedSetStakes(i);
             if (_account != account) continue;
 
+            (,, uint courtMinStake,,,) = klerosLiquid.courts(subcourtID);
+
             if (stake == 0) {
                 for (uint j = 0; j < subcourtIDs.length; j++) {
                     if (subcourtID + 1 == subcourtIDs[j]) {
@@ -83,19 +85,13 @@ contract xKlerosLiquidExtraViews {
                         break;
                     }
                 }
-            } else {
-                uint courtMinStake;
+            } else if (stake >= courtMinStake) {
                 bool subcourtFound = false;
                 // First, look for the subcourt among the subcourts the user has already staked in.
                 for (j = 0; j < subcourtIDs.length; j++) {
                     if (subcourtID + 1 != subcourtIDs[j]) continue; // Keep looking
 
-                    (,, courtMinStake,,,) = klerosLiquid.courts(subcourtIDs[j] - 1);
-                    if (
-                        courtMinStake <= stake &&
-                        klerosLiquid.pinakion().balanceOf(_account) >= stakedTokens - subcourtStakes[j] + stake
-                    ) {
-                        subcourtIDs[j] = subcourtID + 1;
+                    if (klerosLiquid.pinakion().balanceOf(_account) >= stakedTokens - subcourtStakes[j] + stake) {
                         stakedTokens = stakedTokens - subcourtStakes[j] + stake;
                         subcourtStakes[j] = stake;
                     }
@@ -108,11 +104,7 @@ contract xKlerosLiquidExtraViews {
                     for (j = 0; j < subcourtIDs.length; j++) {
                         if (subcourtIDs[j] != 0) continue; // subcourt already set.
 
-                        (,, courtMinStake,,,) = klerosLiquid.courts(subcourtID);
-                        if (
-                            courtMinStake <= stake &&
-                            klerosLiquid.pinakion().balanceOf(_account) >= stakedTokens - subcourtStakes[j] + stake
-                        ) {
+                        if (klerosLiquid.pinakion().balanceOf(_account) >= stakedTokens - subcourtStakes[j] + stake) {
                             subcourtIDs[j] = subcourtID + 1;
                             stakedTokens = stakedTokens - subcourtStakes[j] + stake;
                             subcourtStakes[j] = stake;

--- a/contracts/kleros/xKlerosLiquidExtraViews.sol
+++ b/contracts/kleros/xKlerosLiquidExtraViews.sol
@@ -86,6 +86,7 @@ contract xKlerosLiquidExtraViews {
             } else {
                 uint courtMinStake;
                 bool subcourtFound = false;
+                // First, look for the subcourt among the subcourts the user has already staked in.
                 for (j = 0; j < subcourtIDs.length; j++) {
                     if (subcourtID + 1 != subcourtIDs[j]) continue; // Keep looking
 
@@ -102,6 +103,8 @@ contract xKlerosLiquidExtraViews {
                     break;
                 }
                 if (!subcourtFound) {
+                    // The user's stake in the subcourt is 0 at the moment. 
+                    // If there is space, add the subcourt ID and the new stake to the list.
                     for (j = 0; j < subcourtIDs.length; j++) {
                         if (subcourtIDs[j] != 0) continue; // subcourt already set.
 


### PR DESCRIPTION
This should fix the following problems that arose when fetching data from delayed stakes:
 
1. The minStake query was wrong. The contract was looking for the wrong subcourt, which in some cases didn't even existed and resulted in a revert.
2. If the user didn't have stake in a court yet, the delayed stake was repeated until the 4 staking paths were filled. One of the consequences was an overestimation of stakedTokens if the PNK balance of the user allowed it.
3. If a user had two o more valid delayed stakes, only the first one was processed and the rest ignored.